### PR TITLE
feat: Mewライクなヘルプ機能（hキー）を追加

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -20,6 +20,7 @@ pub fn render_ui(f: &mut Frame, app: &mut App) {
         AppMode::MailList => render_mail_list(f, app, size),
         AppMode::MailView => render_mail_view(f, app, size),
         AppMode::Compose => render_compose(f, app, size),
+        AppMode::Help => render_help(f, app, size),
         AppMode::Settings => render_settings(f, app, size),
     }
 }
@@ -107,6 +108,56 @@ fn render_compose(f: &mut Frame, app: &mut App, area: Rect) {
 fn render_settings(f: &mut Frame, _app: &mut App, area: Rect) {
     let block = Block::default().title("設定").borders(Borders::ALL);
     let paragraph = Paragraph::new("設定機能は未実装です").block(block);
+    f.render_widget(paragraph, area);
+}
+
+fn render_help(f: &mut Frame, _app: &mut App, area: Rect) {
+    let help_text = vec![
+        "RustMail - ヘルプ",
+        "",
+        "■ 基本操作",
+        "  h      : このヘルプを表示",
+        "  q      : アプリケーションを終了",
+        "  Esc    : 前の画面に戻る",
+        "",
+        "■ メール一覧画面",
+        "  j/↓    : 次のメールを選択",
+        "  k/↑    : 前のメールを選択",
+        "  Enter  : 選択したメールを開く",
+        "  c      : 新しいメールを作成",
+        "  r      : 返信",
+        "  R      : 全員に返信",
+        "  f      : 転送",
+        "  d      : 削除",
+        "  /      : 検索",
+        "",
+        "■ メール表示画面",
+        "  q/Esc  : メール一覧に戻る",
+        "  r      : 返信",
+        "  R      : 全員に返信",
+        "  f      : 転送",
+        "  d      : 削除",
+        "",
+        "■ 作成画面",
+        "  Esc    : メール一覧に戻る",
+        "  F10    : メールを送信",
+        "",
+        "■ 検索画面",
+        "  Enter  : 検索実行",
+        "  Esc    : 検索をキャンセル",
+        "",
+        "ヘルプを閉じるには h, q, または Esc キーを押してください",
+    ];
+
+    let paragraph = Paragraph::new(help_text.join("\n"))
+        .block(
+            Block::default()
+                .title("ヘルプ - RustMail")
+                .borders(Borders::ALL),
+        )
+        .style(Style::default().fg(Color::White))
+        .wrap(ratatui::widgets::Wrap { trim: true });
+
     f.render_widget(paragraph, area);
 }
 


### PR DESCRIPTION
## 概要
Mewメールクライアントのように、`h`キーでヘルプ画面を表示する機能を実装しました。

## 変更内容
### 新機能
- **ヘルプモードの追加**: `AppMode::Help`を新たに追加
- **ヘルプ表示機能**: `show_help()`メソッドでヘルプ画面を表示
- **適切な画面復帰**: `hide_help()`メソッドで前の画面に適切に戻る
- **包括的なキーバインド**: どの画面からでも`h`キーでヘルプにアクセス可能

### UI改善
- 日本語による分かりやすいヘルプ画面
- 全ての操作方法を網羅したキーバインド一覧
- 画面ごとに整理された操作説明

## キーバインド
- **h**: ヘルプ画面を表示（全画面共通）
- **ヘルプ画面で h/q/Esc**: ヘルプを閉じて前の画面に戻る

## ヘルプ画面の内容
- ✅ 基本操作（終了、戻る）
- ✅ メール一覧画面の操作
- ✅ メール表示画面の操作
- ✅ 作成画面の操作
- ✅ 検索画面の操作

## テスト方法
1. アプリケーションを起動: `cargo run`
2. 任意の画面で`h`キーを押す
3. ヘルプ画面が表示されることを確認
4. `h`、`q`、または`Esc`キーでヘルプを閉じる
5. 元の画面に正しく戻ることを確認

## 影響範囲
- `src/app.rs`: AppMode enum、キーハンドリング、ヘルプ関連メソッド
- `src/ui/mod.rs`: ヘルプ画面のレンダリング機能

## 備考
- 既存機能には影響なし
- Mewの使用感を参考にしたユーザビリティ向上
- 今後の機能追加時もヘルプ画面を更新することで一貫したUXを維持